### PR TITLE
30807 fix `lower-level-imports`: import a node module when `useLevelNumber=true`

### DIFF
--- a/lib/helpers/lowerLevelImports/1 layer.js
+++ b/lib/helpers/lowerLevelImports/1 layer.js
@@ -79,6 +79,7 @@ const reportHasProperLevelNumber = (context, options, rootDir, filePath) => {
    */
   return (node, modulePath) => {
     if (!options.useLevelNumber) return;
+    if (isNodeModule(rootDir)(modulePath)) return;
 
     const report = (messageId) =>
       reportError(context, rootDir, filePath)(node, messageId, modulePath);
@@ -184,12 +185,15 @@ const reportHasProperLevel = (
 
     const isNodeModulePath = isNodeModule(rootDir)(modulePath);
 
+    const moduleLevel = findLevel(modulePath);
+
     if (fileLevel === null) {
-      if (!isNodeModulePath) report("not-registered:file");
+      if (moduleLevel !== null || !isNodeModulePath) {
+        report("not-registered:file");
+      }
       return FINISHED;
     }
 
-    const moduleLevel = findLevel(modulePath);
     if (moduleLevel === null) {
       if (!isNodeModulePath) report("not-registered:module");
       return FINISHED;

--- a/tests/lib/rules/lower-level-imports.js
+++ b/tests/lib/rules/lower-level-imports.js
@@ -58,7 +58,7 @@ ruleTester.run("lower-level-imports", rule, {
       options: [{ structure, root: "./src", aliases: { "@/": "./src/" } }],
     },
     {
-      code: "import { func } from 'node-module'",
+      code: "import { func } from 'other-node-module'",
       filename: "./src/otherLayerA.js",
       options: [{ structure, root: "./src" }],
     },
@@ -167,6 +167,23 @@ ruleTester.run("lower-level-imports", rule, {
           root: "./src",
           useLevelNumber: true,
           aliases: { "@/": "./src/" },
+        },
+      ],
+    },
+    {
+      code: "import { func } from 'other-node-module'",
+      filename: "./src/1 otherLayerA.js",
+      options: [{ structure, root: "./src", useLevelNumber: true }],
+    },
+    {
+      code: "import { func } from 'node-module'",
+      filename: "./src/layer2/subLayer1/1 layer.js",
+      options: [
+        {
+          structure,
+          root: "./src",
+          aliases: { "@/": "./src/" },
+          useLevelNumber: true,
         },
       ],
     },
@@ -307,6 +324,17 @@ ruleTester.run("lower-level-imports", rule, {
             module: "./component/2 layer/1 style",
             file: "./component/1 layer/1 style",
           },
+        },
+      ],
+    },
+    {
+      code: "import { func } from 'node-module'",
+      filename: "./src/layer3/subLayer1/1 layer.js",
+      options: [{ structure, root: "./src", useLevelNumber: true }],
+      errors: [
+        {
+          messageId: "not-lower-level",
+          data: { module: "node-module", file: "./layer3/subLayer1/1 layer" },
         },
       ],
     },


### PR DESCRIPTION
Fix `lower-level-imports`: import a node module when `useLevelNumber=true`