### PR TITLE
30807 `lower-level-imports`: fix barrier error using `useLevelNumber`

### DIFF
--- a/lib/helpers/lowerLevelImports/1 layer.js
+++ b/lib/helpers/lowerLevelImports/1 layer.js
@@ -99,16 +99,20 @@ const reportHasProperLevelNumber = (context, options, rootDir, filePath) => {
       return toPath(parent);
     })();
 
-    const { moduleLevel, isInterfaceError } = (() => {
+    const { moduleLevel, isBarrierError } = (() => {
       const segments = toSegments(toRelative(parentPath, modulePath));
-      const level = extractLevel(segments[1]);
+      const moduleLevel = extractLevel(segments[1]);
+      const isBarrierError =
+        segments.length === 2
+          ? false
+          : segments.some((seg) => extractLevel(seg) !== null);
       return {
-        moduleLevel: level,
-        isInterfaceError: segments.length > 2,
+        moduleLevel,
+        isBarrierError,
       };
     })();
 
-    if (isInterfaceError) {
+    if (isBarrierError) {
       report("barrier");
       return FINISHED;
     }

--- a/tests/lib/rules/lower-level-imports.js
+++ b/tests/lib/rules/lower-level-imports.js
@@ -187,6 +187,18 @@ ruleTester.run("lower-level-imports", rule, {
         },
       ],
     },
+    {
+      code: "import { func } from '@/layer1/subLayer2/sub'",
+      filename: "./src/layer1/subLayer1/1 layer.js",
+      options: [
+        {
+          structure,
+          root: "./src",
+          aliases: { "@/": "./src/" },
+          useLevelNumber: true,
+        },
+      ],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fix `lower-level-imports`: barrier error using `useLevelNumber`