### PR TITLE
30819 `no-same-level-funcs`: `@level` comment

### DIFF
--- a/docs/rules/no-same-level-funcs.md
+++ b/docs/rules/no-same-level-funcs.md
@@ -36,6 +36,18 @@ function func3(...) {
 }
 ```
 
+```js
+// @level 1
+const funcA = (...) => { ... }
+
+// @level 2
+const funcB = (...) => {
+  ...
+  funcA(...)
+  ...
+}
+```
+
 Examples of **correct** code for this rule:
 
 ```js
@@ -51,5 +63,17 @@ function func1(...) {
   const func2(...) => { ... };
   ...
   func2(...);
+}
+```
+
+```js
+// @level 2
+const funcA = (...) => { ... }
+
+// @level 1
+const funcB = (...) => {
+  ...
+  funcA(...)
+  ...
 }
 ```

--- a/lib/rules/no-same-level-funcs.js
+++ b/lib/rules/no-same-level-funcs.js
@@ -129,7 +129,7 @@ module.exports = {
         if (calleeLevel !== null) {
           const ancestor = traceAncestor(node);
           const ancestorLevel = deriveLevel(sourceCode, ancestor);
-          if (ancestorLevel < calleeLevel) return;
+          if (ancestorLevel !== null && ancestorLevel < calleeLevel) return;
         }
         context.report({
           node,

--- a/lib/rules/no-same-level-funcs.js
+++ b/lib/rules/no-same-level-funcs.js
@@ -11,6 +11,43 @@ const path = require("path");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @typedef {import('eslint').Rule.Node} Node
+ * @typedef {import('eslint').AST.Token} Token
+ * @typedef {import('eslint').SourceCode} SourceCode
+ */
+
+/**
+ * @param {SourceCode} sourceCode
+ * @param {Node | Token} nodeOrToken
+ *
+ */
+const deriveLevel = (sourceCode, nodeOrToken) => {
+  const comments = sourceCode.getCommentsBefore(nodeOrToken);
+  for (const { value } of comments) {
+    const levelInStr = value.replace(/^[^]*@level\s+?([0-9]+)[^0-9]*$/, "$1");
+    const levelInNum = Number(levelInStr);
+    if (levelInStr && !Number.isNaN(levelInNum)) {
+      return levelInNum;
+    }
+  }
+  return null;
+};
+
+/**
+ *
+ * @param {Node} node
+ */
+const traceAncestor = (node) => {
+  let parent = node;
+  let nextParent = node.parent;
+  while (nextParent.type !== "Program") {
+    parent = parent.parent;
+    nextParent = parent.parent;
+  }
+  return parent;
+};
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -36,10 +73,9 @@ module.exports = {
       additionalItems: false,
     },
     messages: {
-      "no-same-level-funcs": "Disallow calling {{func}} in the same file.",
+      "no-same-level-funcs": "{{func}} is NOT lower level",
     },
   },
-
   create(context) {
     const options = {
       exclude: ["**/*.{test,spec}.{js,ts,jsx,tsx}"],
@@ -59,31 +95,47 @@ module.exports = {
 
     if (isExcludedFile) return {};
 
-    let funcNames;
+    /**
+     * @type {({[name: string]: number | null})}
+     */
+    const levels = {};
+
+    const sourceCode = context.getSourceCode();
 
     return {
       Program(node) {
-        funcNames = node.body.reduce((names, { type, id, declarations }) => {
-          if (type === "FunctionDeclaration") {
-            names.push(id.name);
-          } else if (
-            type === "VariableDeclaration" &&
-            (declarations[0].init.type === "ArrowFunctionExpression" ||
-              declarations[0].init.type === "FunctionExpression")
-          ) {
-            names.push(declarations[0].id.name);
+        node.body.forEach((token) => {
+          const isFuncDeclaration = token.type === "FunctionDeclaration";
+          const isVarDeclaration =
+            token.type === "VariableDeclaration" &&
+            [
+              "ArrowFunctionExpression",
+              "FunctionExpression",
+              "CallExpression",
+            ].includes(token.declarations[0].init.type);
+
+          if (isFuncDeclaration || isVarDeclaration) {
+            const level = deriveLevel(sourceCode, token);
+            const name = isFuncDeclaration
+              ? token.id.name
+              : token.declarations[0].id.name;
+            levels[name] = level;
           }
-          return names;
-        }, []);
+        });
       },
       CallExpression(node) {
-        if (funcNames.includes(node.callee.name)) {
-          context.report({
-            node,
-            messageId: "no-same-level-funcs",
-            data: { func: node.callee.name },
-          });
+        const calleeLevel = levels[node.callee.name];
+        if (calleeLevel === undefined) return;
+        if (calleeLevel !== null) {
+          const ancestor = traceAncestor(node);
+          const ancestorLevel = deriveLevel(sourceCode, ancestor);
+          if (ancestorLevel < calleeLevel) return;
         }
+        context.report({
+          node,
+          messageId: "no-same-level-funcs",
+          data: { func: node.callee.name },
+        });
       },
     };
   },

--- a/tests/lib/rules/no-same-level-funcs.js
+++ b/tests/lib/rules/no-same-level-funcs.js
@@ -44,6 +44,30 @@ ruleTester.run("no-same-level-funcs", rule, {
       filename: "./src/foo.js",
       options: [{ include: ["**/src/**/*.*"], exclude: ["**/foo.js"] }],
     },
+    {
+      code: "// @level 2\nfunction func2(){};\n// @level 1\nfunction func1(){ func2(); }",
+      filename: "./src/foo.js",
+    },
+    {
+      code: "// @level 2\nconst func2 = () => {};\n// @level 1\nfunction func1(){ func2(); }",
+      filename: "./src/foo.js",
+    },
+    {
+      code: "// @level 2\nconst func2 = () => {};\n// @level 1\nconst func1 = () => func2();",
+      filename: "./src/foo.js",
+    },
+    {
+      code: "/*@level 2*/\nconst func2 = () => {};\n/*@level 1*/\nconst func1 = () => func2();",
+      filename: "./src/foo.js",
+    },
+    {
+      code: "// @level 2 something\nconst func2 = () => {};\n// @level 1 something\nconst func1 = () => func2();",
+      filename: "./src/foo.js",
+    },
+    {
+      code: "/*\n@level 2\nsomething\n*/\nconst func2 = () => {};\n/*something\n@level 1\n*/\nconst func1 = () => func2();",
+      filename: "./src/foo.js",
+    },
   ],
   invalid: [
     {
@@ -68,6 +92,26 @@ ruleTester.run("no-same-level-funcs", rule, {
     },
     {
       code: "const func1 = function func1(){}; const func2 = function func2(){ func1(); }",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "func1" } }],
+    },
+    {
+      code: "const fn = () => 1; const value = fn()",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "fn" } }],
+    },
+    {
+      code: "const fnByHof = hof(() => 1); const value = fnByHof()",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "fnByHof" } }],
+    },
+    {
+      code: "const fnByHof = hof(() => 1); const fn = fnByHof(() => 1)",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "fnByHof" } }],
+    },
+    {
+      code: "// @level 1\nfunction func1(){};\n// @level 2\nfunction func2(){ func1(); }",
       filename: "./src/foo.js",
       errors: [{ messageId: "no-same-level-funcs", data: { func: "func1" } }],
     },

--- a/tests/lib/rules/no-same-level-funcs.js
+++ b/tests/lib/rules/no-same-level-funcs.js
@@ -115,5 +115,15 @@ ruleTester.run("no-same-level-funcs", rule, {
       filename: "./src/foo.js",
       errors: [{ messageId: "no-same-level-funcs", data: { func: "func1" } }],
     },
+    {
+      code: "// @level 2\nfunction func2(){};\nfunction func1(){ func2(); }",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "func2" } }],
+    },
+    {
+      code: "function func2(){};\n// @level 1\nfunction func1(){ func2(); }",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "func2" } }],
+    },
   ],
 });


### PR DESCRIPTION
New feature of `no-same-level-funcs` rule: register level using `@level` comment
