### PR TITLE
30921 fix

### DIFF
--- a/docs/rules/no-disallowed-imports.md
+++ b/docs/rules/no-disallowed-imports.md
@@ -16,17 +16,17 @@ To control module imports, use the `imports` option:
     {
       "imports": [
         {
-          "import": { "member": ["foo"], "from": "**/src/fileA" },
-          "allow": ["**/src/some-dir/*.js"]
+          "import": { "member": ["foo"], "from": "src/fileA" },
+          "allow": ["src/some-dir/*.js"]
         },
         {
-          "import": { "member": ["foo", "bar"], "from": "**/src/fileB" },
-          "disallow": ["**/src/not-allowed-file.js"]
+          "import": { "member": ["foo", "bar"], "from": "src/fileB" },
+          "disallow": ["src/not-allowed-file.js"]
         },
         {
-          "import": { "member": ["baz"], "from": "**/src/fileC" },
-          "allow": ["**/src/some-dir/*.js"],
-          "disallow": ["**/src/not-allowed-file.js"]
+          "import": { "member": ["baz"], "from": "src/fileC" },
+          "allow": ["src/some-dir/*.js"],
+          "disallow": ["src/not-allowed-file.js"]
         }
       ]
     }
@@ -57,9 +57,9 @@ Examples of **incorrect** code for this rule:
 //   {
 //     "imports": [
 //       {
-//         "import": { "member": ["foo"], "from": "**/src/fileA" },
-//         "allow": ["**/src/**/fileB.js"],
-//         "disallow": ["**/src/**/fileC.*"]
+//         "import": { "member": ["foo"], "from": "src/fileA" },
+//         "allow": ["src/**/fileB.js"],
+//         "disallow": ["src/**/fileC.*"]
 //       }
 //     ]
 //   }
@@ -77,9 +77,9 @@ Examples of **correct** code for this rule:
 //   {
 //     "imports": [
 //       {
-//         "import": { "member": ["foo"], "from": "**/src/fileA" },
-//         "allow": ["**/src/**/fileB.js"],
-//         "disallow": ["**/src/**/fileC.*"]
+//         "import": { "member": ["foo"], "from": "src/fileA" },
+//         "allow": ["src/**/fileB.js"],
+//         "disallow": ["src/**/fileC.*"]
 //       }
 //     ]
 //   }

--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -1,3 +1,4 @@
+const { minimatch } = require("minimatch");
 const p = require("path");
 
 /**
@@ -116,6 +117,23 @@ const replaceAlias = (cwd, fileDir, aliases) => {
   };
 };
 
+// @level 1
+/**
+ * @param {string} cwd
+ * @param {string} path
+ */
+const fromCwd = (cwd, path) => p.relative(cwd, path);
+
+/**
+ * @param {string} path
+ */
+const match = (path) => {
+  /**
+   * @param {string} pattern
+   */
+  return (pattern) => minimatch(path, pattern);
+};
+
 module.exports = {
   toRelative,
   toSegments,
@@ -129,4 +147,6 @@ module.exports = {
   reducedPaths,
   createAliases,
   replaceAlias,
+  fromCwd,
+  match,
 };

--- a/lib/helpers/lowerLevelImports/1 layer.js
+++ b/lib/helpers/lowerLevelImports/1 layer.js
@@ -1,4 +1,3 @@
-const { minimatch } = require("minimatch");
 const { report: reportError } = require("./2 layer");
 const {
   isNodeModule,
@@ -12,6 +11,8 @@ const {
   toPath,
   resolvePath,
   parsePath,
+  fromCwd,
+  match,
 } = require("../common");
 
 const FINISHED = "finished";
@@ -28,19 +29,17 @@ const createRootDir = (cwd, options) => {
 
 /**
  * @param {import("./3 layer").Options} options
+ * @param {string} cwd
  * @param {string} contextFileSource
  */
-const parseFileSource = (options, contextFileSource) => {
+const parseFileSource = (options, cwd, contextFileSource) => {
   const fileSource = resolvePath(contextFileSource);
   const parsedFileSource = parsePath(fileSource);
   const fileDir = resolvePath(parsedFileSource.dir);
   const filePath = resolvePath(fileDir, parsedFileSource.name);
-  const isIncludedFile = options.include.find((pattern) =>
-    minimatch(fileSource, pattern)
-  );
-  const isExcludedFile = options.exclude.find((pattern) =>
-    minimatch(fileSource, pattern)
-  );
+  const fileSourceFromCwd = fromCwd(cwd, fileSource);
+  const isIncludedFile = options.include.find(match(fileSourceFromCwd));
+  const isExcludedFile = options.exclude.find(match(fileSourceFromCwd));
   return {
     fileDir,
     filePath,
@@ -61,13 +60,21 @@ const createModulePath = (cwd, excludeImports, fileDir, aliases) => {
    */
   return (moduleSourceWithAlias) => {
     const moduleSource = removeAlias(moduleSourceWithAlias);
+
     const isNodeModule = moduleSource.startsWith(".") === false;
+
     const modulePath = isNodeModule
       ? moduleSource
       : resolvePath(fileDir, moduleSource);
+
+    const modulePathFromCwd = isNodeModule
+      ? modulePath
+      : fromCwd(cwd, modulePath);
+
     const isModuleExcluded = Boolean(
-      excludeImports.find((pattern) => minimatch(modulePath, pattern))
+      excludeImports.find(match(modulePathFromCwd))
     );
+
     return { modulePath, isModuleExcluded };
   };
 };

--- a/lib/helpers/stratifiedImports/1 layer.js
+++ b/lib/helpers/stratifiedImports/1 layer.js
@@ -1,11 +1,12 @@
 "use strict";
 
-const { minimatch } = require("minimatch");
 const {
   resolvePath,
   reducedPaths,
   parsePath,
   replaceAlias,
+  fromCwd,
+  match,
 } = require("../common");
 const {
   findLevel,
@@ -35,18 +36,20 @@ const BARRIER = "barrier";
 // @level 2
 /**
  * @param {Options} options
+ * @param {string} cwd
  * @param {string} contextFileSource
  */
-const parseFileSource = (options, contextFileSource) => {
+const parseFileSource = (options, cwd, contextFileSource) => {
   const fileSource = resolvePath(contextFileSource);
   const parsedFileSource = parsePath(fileSource);
   const fileDir = resolvePath(parsedFileSource.dir);
   const filePath = resolvePath(fileDir, parsedFileSource.name);
+  const fileSourceFromCwd = fromCwd(cwd, fileSource);
   const isIncludedFile = Boolean(
-    options.include.find((pattern) => minimatch(fileSource, pattern))
+    options.include.find(match(fileSourceFromCwd))
   );
   const isExcludedFile = Boolean(
-    options.exclude.find((pattern) => minimatch(fileSource, pattern))
+    options.exclude.find(match(fileSourceFromCwd))
   );
   return {
     fileDir,
@@ -72,13 +75,21 @@ const createModulePath = (cwd, excludeImports, fileDir, aliases) => {
       fileDir,
       aliases
     )(moduleSourceWithAlias);
+
     const isNodeModule = moduleSource.startsWith(".") === false;
+
     const modulePath = isNodeModule
       ? moduleSource
       : resolvePath(fileDir, moduleSource);
+
+    const modulePathFromCwd = isNodeModule
+      ? modulePath
+      : fromCwd(cwd, modulePath);
+
     const isModuleExcluded = Boolean(
-      excludeImports.find((pattern) => minimatch(modulePath, pattern))
+      excludeImports.find(match(modulePathFromCwd))
     );
+
     return { modulePath, isModuleExcluded };
   };
 };

--- a/lib/rules/lower-level-imports.js
+++ b/lib/rules/lower-level-imports.js
@@ -131,6 +131,7 @@ module.exports = {
 
     const { fileDir, filePath, isExcludedFile } = parseFileSource(
       options,
+      context.cwd,
       context.filename
     );
 

--- a/lib/rules/no-disallowed-imports.js
+++ b/lib/rules/no-disallowed-imports.js
@@ -28,6 +28,8 @@ const { createAliases, fromCwd, match } = require("../helpers/common");
 
 const DEFAULT = "default";
 
+const NAMESPACE = "*";
+
 const importSchema = {
   type: "object",
   properties: {
@@ -128,6 +130,7 @@ module.exports = {
             if (specifier.type === "ImportSpecifier")
               return specifier.imported.name;
             if (specifier.type === "ImportDefaultSpecifier") return DEFAULT;
+            if (specifier.type === "ImportNamespaceSpecifier") return NAMESPACE;
             return "";
           });
 
@@ -139,10 +142,12 @@ module.exports = {
             member &&
             match(fromCwd(context.cwd, modulePath))(importSpec.import.from)
           ) {
-            if (member === DEFAULT) {
+            if (member === DEFAULT || member === NAMESPACE) {
               return [
                 node.specifiers.find(
-                  ({ type }) => type === "ImportDefaultSpecifier"
+                  ({ type }) =>
+                    type === "ImportDefaultSpecifier" ||
+                    type === "ImportNamespaceSpecifier"
                 ).local.name,
                 importSpec,
               ];

--- a/lib/rules/no-disallowed-imports.js
+++ b/lib/rules/no-disallowed-imports.js
@@ -4,9 +4,8 @@
  */
 "use strict";
 
-const { minimatch } = require("minimatch");
 const helpers = require("../helpers/noDisallowedImports");
-const { createAliases } = require("../helpers/common");
+const { createAliases, fromCwd, match } = require("../helpers/common");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -125,8 +124,6 @@ module.exports = {
             return [theMember, theImportSpec];
           }
 
-          // const { member, from } = importSpec.import;
-
           const importedSpecifiers = node.specifiers.map((specifier) => {
             if (specifier.type === "ImportSpecifier")
               return specifier.imported.name;
@@ -138,7 +135,10 @@ module.exports = {
             importedSpecifiers.some((sp) => sp === specifier)
           );
 
-          if (member && minimatch(modulePath, importSpec.import.from)) {
+          if (
+            member &&
+            match(fromCwd(context.cwd, modulePath))(importSpec.import.from)
+          ) {
             if (member === DEFAULT) {
               return [
                 node.specifiers.find(
@@ -160,13 +160,10 @@ module.exports = {
         if (!theMember || !theImportSpec) return;
 
         const { allow, disallow } = theImportSpec;
+        const fileSourceFromCwd = fromCwd(context.cwd, fileSource);
         const isAllowed =
-          (allow
-            ? Boolean(allow.find((pattern) => minimatch(fileSource, pattern)))
-            : true) &&
-          (disallow
-            ? !disallow.find((pattern) => minimatch(fileSource, pattern))
-            : true);
+          (allow ? Boolean(allow.find(match(fileSourceFromCwd))) : true) &&
+          (disallow ? !disallow.find(match(fileSourceFromCwd)) : true);
         if (isAllowed) return;
 
         context.report({

--- a/lib/rules/no-same-level-funcs.js
+++ b/lib/rules/no-same-level-funcs.js
@@ -4,8 +4,8 @@
  */
 "use strict";
 
-const { minimatch } = require("minimatch");
 const path = require("path");
+const { fromCwd, match } = require("../helpers/common");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -95,6 +95,9 @@ module.exports = {
     },
   },
   create(context) {
+    /**
+     * @type {{include: string[], exclude: string[]}}
+     */
     const options = {
       exclude: ["**/*.{test,spec}.{js,ts,jsx,tsx}"],
       include: ["**/*.{js,ts,jsx,tsx}"],
@@ -103,13 +106,12 @@ module.exports = {
 
     const fileSource = path.resolve(context.filename);
 
-    const isIncludedFile = options.include.find((pattern) =>
-      minimatch(fileSource, pattern)
-    );
+    const fileSourceFromCwd = fromCwd(context.cwd, fileSource);
+
+    const isIncludedFile = options.include.find(match(fileSourceFromCwd));
 
     const isExcludedFile =
-      !isIncludedFile ||
-      options.exclude.find((pattern) => minimatch(fileSource, pattern));
+      !isIncludedFile || options.exclude.find(match(fileSourceFromCwd));
 
     if (isExcludedFile) return {};
 
@@ -145,6 +147,7 @@ module.exports = {
               "ArrowFunctionExpression",
               "FunctionExpression",
               "CallExpression",
+              "TaggedTemplateExpression",
             ].includes(token.declarations[0].init.type);
 
           if (isFuncDeclaration || isVarDeclaration) {

--- a/lib/rules/stratified-imports.js
+++ b/lib/rules/stratified-imports.js
@@ -74,6 +74,7 @@ module.exports = {
 
     const { fileDir, filePath, isExcludedFile } = helper.parseFileSource(
       options,
+      context.cwd,
       context.filename
     );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-stratified-design",
-  "version": "0.9.0",
+  "version": "0.9.1-beta",
   "description": "ESlint rules for stratified design",
   "keywords": [
     "eslint",

--- a/tests-in-package/.eslintrc.js
+++ b/tests-in-package/.eslintrc.js
@@ -17,5 +17,9 @@ module.exports = {
         useLevelNumber: true,
       },
     ],
+    "stratified-design/no-same-level-funcs": [
+      "error",
+      { exclude: ["src/layer1/module.js"] },
+    ],
   },
 };

--- a/tests-in-package/package-lock.json
+++ b/tests-in-package/package-lock.json
@@ -9,7 +9,7 @@
       }
     },
     "..": {
-      "version": "0.3.2",
+      "version": "0.9.0",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/tests-in-package/src/layer1/module.js
+++ b/tests-in-package/src/layer1/module.js
@@ -1,3 +1,11 @@
 import { func } from "../layer3/1 lib"; // lint error occurs!!
 
 func(1);
+
+const fn1 = () => "";
+
+const fn2 = () => {
+  fn1();
+};
+
+export { fn2 };

--- a/tests/lib/helpers/lower-level-imports.js
+++ b/tests/lib/helpers/lower-level-imports.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview test for helpers/stratified-imports
+ * @fileoverview test for helpers/lower-level-imports
  * @author Hodoug Joung
  */
 "use strict";
@@ -17,7 +17,7 @@ const {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("helpers/stratified-imports", () => {
+describe("helpers/lower-level-imports", () => {
   describe("createModulePath()", () => {
     const cwd = "/proj";
     const fileDir = "/proj/src/layerA";

--- a/tests/lib/helpers/stratified-imports.js
+++ b/tests/lib/helpers/stratified-imports.js
@@ -208,6 +208,7 @@ describe("helpers/stratified-imports", () => {
 
   describe("parseFileSource()", () => {
     const makeOptions = (options) => ({ alias: {}, ...options });
+    const cwd = "proj";
     const fileSource = "proj/src/layerA/layerAA.js";
     const testCases = [
       {
@@ -246,7 +247,7 @@ describe("helpers/stratified-imports", () => {
     ];
     testCases.forEach(({ options, expected }) => {
       it(`${JSON.stringify(options)} => ${JSON.stringify(expected)}`, () => {
-        assert.deepEqual(parseFileSource(options, fileSource), expected);
+        assert.deepEqual(parseFileSource(options, cwd, fileSource), expected);
       });
     });
   });

--- a/tests/lib/rules/lower-level-imports.js
+++ b/tests/lib/rules/lower-level-imports.js
@@ -118,7 +118,7 @@ ruleTester.run("lower-level-imports", rule, {
           structure,
           root: "./src",
           include: ["**/*.js"],
-          exclude: ["**/otherLayerA.test.js"],
+          exclude: ["src/otherLayerA.test.js"],
         },
       ],
     },

--- a/tests/lib/rules/no-disallowed-imports.js
+++ b/tests/lib/rules/no-disallowed-imports.js
@@ -49,25 +49,11 @@ ruleTester.run("no-disallowed-imports", rule, {
           imports: [
             {
               import: { member: ["baz"], from: "**/src/fileC" },
-              allow: ["**/src/**/*.js"],
+              allow: ["src/**/*.js"],
             },
             {
               import: { member: ["foo", "bar"], from: "**/src/fileA" },
-              allow: ["**/src/**/*.js"],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: "import { foo } from './fileA'",
-      filename: "./src/fileB.js",
-      options: [
-        {
-          imports: [
-            {
-              import: { member: ["foo", "bar"], from: "**/src/fileA" },
-              disallow: ["**/src/**/*.test.js"],
+              allow: ["src/**/*.js"],
             },
           ],
         },
@@ -81,8 +67,22 @@ ruleTester.run("no-disallowed-imports", rule, {
           imports: [
             {
               import: { member: ["foo", "bar"], from: "**/src/fileA" },
-              allow: ["**/src/**/*.js"],
-              disallow: ["**/src/**/*.test.js"],
+              disallow: ["src/**/*.test.js"],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: "import { foo } from './fileA'",
+      filename: "./src/fileB.js",
+      options: [
+        {
+          imports: [
+            {
+              import: { member: ["foo", "bar"], from: "**/src/fileA" },
+              allow: ["src/**/*.js"],
+              disallow: ["src/**/*.test.js"],
             },
           ],
         },
@@ -96,7 +96,7 @@ ruleTester.run("no-disallowed-imports", rule, {
           imports: [
             {
               import: { member: ["foo"], from: "**/src/fileA" },
-              allow: ["**/src/**/*.js"],
+              allow: ["src/**/*.js"],
             },
           ],
           aliases: { "@/": "./src/" },
@@ -111,7 +111,7 @@ ruleTester.run("no-disallowed-imports", rule, {
           imports: [
             {
               import: { member: ["default"], from: "**/src/fileA" },
-              allow: ["**/src/**/*.js"],
+              allow: ["src/**/*.js"],
             },
           ],
         },
@@ -127,7 +127,7 @@ ruleTester.run("no-disallowed-imports", rule, {
           imports: [
             {
               import: { member: ["foo"], from: "**/src/fileA" },
-              allow: ["**/src/**/*.test.js"],
+              allow: ["src/**/*.test.js"],
             },
           ],
         },
@@ -142,7 +142,7 @@ ruleTester.run("no-disallowed-imports", rule, {
           imports: [
             {
               import: { member: ["foo"], from: "**/src/fileA" },
-              disallow: ["**/src/**/*.js"],
+              disallow: ["src/**/*.js"],
             },
           ],
         },
@@ -157,8 +157,8 @@ ruleTester.run("no-disallowed-imports", rule, {
           imports: [
             {
               import: { member: ["foo"], from: "**/src/fileA" },
-              allow: ["**/src/**/*.js"],
-              disallow: ["**/src/**/fileB.*"],
+              allow: ["src/**/*.js"],
+              disallow: ["src/**/fileB.*"],
             },
           ],
         },
@@ -173,7 +173,7 @@ ruleTester.run("no-disallowed-imports", rule, {
           imports: [
             {
               import: { member: ["default"], from: "**/src/fileA" },
-              disallow: ["**/src/**/*.js"],
+              disallow: ["src/**/*.js"],
             },
           ],
         },

--- a/tests/lib/rules/no-disallowed-imports.js
+++ b/tests/lib/rules/no-disallowed-imports.js
@@ -37,7 +37,7 @@ ruleTester.run("no-disallowed-imports", rule, {
       filename: "./src/fileB.js",
       options: [
         {
-          imports: [{ import: { member: ["foo"], from: "**/src/fileA" } }],
+          imports: [{ import: { member: ["foo"], from: "src/fileA" } }],
         },
       ],
     },
@@ -48,11 +48,11 @@ ruleTester.run("no-disallowed-imports", rule, {
         {
           imports: [
             {
-              import: { member: ["baz"], from: "**/src/fileC" },
+              import: { member: ["baz"], from: "src/fileC" },
               allow: ["src/**/*.js"],
             },
             {
-              import: { member: ["foo", "bar"], from: "**/src/fileA" },
+              import: { member: ["foo", "bar"], from: "src/fileA" },
               allow: ["src/**/*.js"],
             },
           ],
@@ -66,7 +66,7 @@ ruleTester.run("no-disallowed-imports", rule, {
         {
           imports: [
             {
-              import: { member: ["foo", "bar"], from: "**/src/fileA" },
+              import: { member: ["foo", "bar"], from: "src/fileA" },
               disallow: ["src/**/*.test.js"],
             },
           ],
@@ -80,7 +80,7 @@ ruleTester.run("no-disallowed-imports", rule, {
         {
           imports: [
             {
-              import: { member: ["foo", "bar"], from: "**/src/fileA" },
+              import: { member: ["foo", "bar"], from: "src/fileA" },
               allow: ["src/**/*.js"],
               disallow: ["src/**/*.test.js"],
             },
@@ -95,7 +95,7 @@ ruleTester.run("no-disallowed-imports", rule, {
         {
           imports: [
             {
-              import: { member: ["foo"], from: "**/src/fileA" },
+              import: { member: ["foo"], from: "src/fileA" },
               allow: ["src/**/*.js"],
             },
           ],
@@ -110,7 +110,21 @@ ruleTester.run("no-disallowed-imports", rule, {
         {
           imports: [
             {
-              import: { member: ["default"], from: "**/src/fileA" },
+              import: { member: ["default"], from: "src/fileA" },
+              allow: ["src/**/*.js"],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: "import * as name from './fileA'",
+      filename: "./src/fileB.js",
+      options: [
+        {
+          imports: [
+            {
+              import: { member: ["*"], from: "src/fileA" },
               allow: ["src/**/*.js"],
             },
           ],
@@ -126,7 +140,7 @@ ruleTester.run("no-disallowed-imports", rule, {
         {
           imports: [
             {
-              import: { member: ["foo"], from: "**/src/fileA" },
+              import: { member: ["foo"], from: "src/fileA" },
               allow: ["src/**/*.test.js"],
             },
           ],
@@ -141,7 +155,7 @@ ruleTester.run("no-disallowed-imports", rule, {
         {
           imports: [
             {
-              import: { member: ["foo"], from: "**/src/fileA" },
+              import: { member: ["foo"], from: "src/fileA" },
               disallow: ["src/**/*.js"],
             },
           ],
@@ -156,7 +170,7 @@ ruleTester.run("no-disallowed-imports", rule, {
         {
           imports: [
             {
-              import: { member: ["foo"], from: "**/src/fileA" },
+              import: { member: ["foo"], from: "src/fileA" },
               allow: ["src/**/*.js"],
               disallow: ["src/**/fileB.*"],
             },
@@ -172,13 +186,30 @@ ruleTester.run("no-disallowed-imports", rule, {
         {
           imports: [
             {
-              import: { member: ["default"], from: "**/src/fileA" },
+              import: { member: ["default"], from: "src/fileA" },
               disallow: ["src/**/*.js"],
             },
           ],
         },
       ],
       errors: [{ messageId: "no-disallowed-imports", data: { member: "foo" } }],
+    },
+    {
+      code: "import * as name from './fileA'",
+      filename: "./src/fileB.js",
+      options: [
+        {
+          imports: [
+            {
+              import: { member: ["*"], from: "src/fileA" },
+              disallow: ["src/**/*.js"],
+            },
+          ],
+        },
+      ],
+      errors: [
+        { messageId: "no-disallowed-imports", data: { member: "name" } },
+      ],
     },
   ],
 });

--- a/tests/lib/rules/no-same-level-funcs.js
+++ b/tests/lib/rules/no-same-level-funcs.js
@@ -48,7 +48,7 @@ ruleTester.run("no-same-level-funcs", rule, {
     {
       code: "function func1(){}; function func2(){ func1(); }",
       filename: "./src/foo.js",
-      options: [{ include: ["**/src/**/*.*"], exclude: ["**/foo.js"] }],
+      options: [{ include: ["src/**/*.*"], exclude: ["src/foo.js"] }],
     },
     {
       code: "// @level 2\nfunction func2(){};\n// @level 1\nfunction func1(){ func2(); }",
@@ -125,6 +125,16 @@ ruleTester.run("no-same-level-funcs", rule, {
       code: "const fn = () => 1; const fnByHof = hof(fn)",
       filename: "./src/foo.js",
       errors: [{ messageId: "no-same-level-funcs", data: { func: "fn" } }],
+    },
+    {
+      code: "const fn1 = template``; const fn2 = () => fn1();",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "fn1" } }],
+    },
+    {
+      code: "const Comp1 = styled.div``; const Comp2 = () => <Comp1 />",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "Comp1" } }],
     },
     {
       code: "function CompA() { return <div /> }; function CompB() { return <CompA /> };",


### PR DESCRIPTION
### no-disallowed-imports

- The CWD is the root directory for `allow` and `disallow` options.
- Handle `ImportNamespaceSpecifier`.

### lower-level-imports

- The CWD is the root directory for `include` and `exclude` options.

### stratified-imports

- The CWD is the root directory for `include` and `exclude` options.

### no-same-level-funcs

- The CWD is the root directory for `include` and `exclude` options.
- Handle `TaggedTemplateExpression`

