### PR TITLE
31014 fix: import only first child layer

### DIFF
--- a/lib/helpers/stratifiedImports/1 layer.js
+++ b/lib/helpers/stratifiedImports/1 layer.js
@@ -124,7 +124,7 @@ const findLevelInChild = (structure) => {
     const fileDir = layer.name;
     const childStructure = readStructure(fileDir);
     const childLevel = findLevel(childStructure)(modulePath);
-    return childLevel !== null ? findLevel(structure)(fileDir) : null;
+    return childLevel === 0 ? findLevel(structure)(fileDir) : null;
   };
 };
 

--- a/mocked/stratified-imports/layerB/.stratified.json
+++ b/mocked/stratified-imports/layerB/.stratified.json
@@ -1,1 +1,1 @@
-[["layerBA"], ["layerBB"]]
+[["index", "layerBA"], ["layerBB"]]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-stratified-design",
-  "version": "0.9.1",
+  "version": "0.9.2-beta",
   "description": "ESlint rules for stratified design",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/stratified-imports.js
+++ b/tests/lib/rules/stratified-imports.js
@@ -32,7 +32,7 @@ const RuleTester = require("eslint").RuleTester;
 
 // layerB/.stratified.json
 [
-  ["layerBA"],
+  ["index", "layerBA"],
   ["layerBB"]
 ]
 
@@ -276,6 +276,28 @@ ruleTester.run("stratified-imports", rule, {
         {
           messageId: "not-lower-level",
           data: { module: "notRegisteredEntry", file: "layerI" },
+        },
+      ],
+    },
+    {
+      code: "import { func } from './layerB/layerBB'",
+      filename: "./mocked/stratified-imports/layerA.js",
+      options: [],
+      errors: [
+        {
+          messageId: "not-lower-level",
+          data: { module: "layerBB", file: "layerA" },
+        },
+      ],
+    },
+    {
+      code: "import { func } from './layerD/layerDB/layerDBA'",
+      filename: "./mocked/stratified-imports/layerC.js",
+      options: [],
+      errors: [
+        {
+          messageId: "not-lower-level",
+          data: { module: "layerDBA", file: "layerC" },
         },
       ],
     },


### PR DESCRIPTION
### stratified-imports

Fix: import only the first child layer