### PR TITLE
[no-same-level-funcs] fix: object and array declaration

### DIFF
--- a/lib/rules/no-same-level-funcs.js
+++ b/lib/rules/no-same-level-funcs.js
@@ -111,6 +111,31 @@ const deriveVarName = (nodeOrToken, levels) => {
   }
 };
 
+const or = (...args) => {
+  for (const arg of args) {
+    try {
+      const result = arg();
+      if (result) return result;
+      else continue;
+    } catch (e) {
+      continue;
+    }
+  }
+  return undefined;
+};
+
+const deriveNames = (nodeOrToken) => {
+  const declaration = deriveDeclaration(nodeOrToken);
+  const names = or(
+    () => declaration.id.name,
+    () => declaration.declarations[0].id.name,
+    () => declaration.declarations[0].id.elements.map(({ name }) => name),
+    () =>
+      declaration.declarations[0].id.properties.map(({ value }) => value.name)
+  );
+  return names === undefined ? [] : Array.isArray(names) ? names : [names];
+};
+
 /**
  * @param {SourceCode} sourceCode
  * @param {Node | Token} nodeOrToken
@@ -243,12 +268,9 @@ module.exports = {
     return {
       Program(node) {
         node.body.forEach((token) => {
-          const name = deriveFuncName(token);
-          if (name !== null) levels[name] = deriveLevel(sourceCode, token);
-        });
-        node.body.forEach((token) => {
-          const name = deriveVarName(token, levels);
-          if (name !== null) levels[name] = deriveLevel(sourceCode, token);
+          deriveNames(token).forEach((name) => {
+            if (name) levels[name] = deriveLevel(sourceCode, token);
+          });
         });
       },
       CallExpression(node) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-stratified-design",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "description": "ESlint rules for stratified design",
   "keywords": [
     "eslint",
@@ -20,6 +20,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha tests --recursive",
+    "test:watch": "mocha tests --recursive --watch",
     "versioning": "node ./scripts/versioning"
   },
   "dependencies": {

--- a/tests/lib/rules/no-same-level-funcs.js
+++ b/tests/lib/rules/no-same-level-funcs.js
@@ -218,6 +218,19 @@ ruleTester.run("no-same-level-funcs", rule, {
       code: "const arr2 = []; const arr1 = [...arr2];",
       filename: "./src/foo.js",
     },
+
+    {
+      code: "//@level 2\nconst [dat, fn2] = someFn()\nconst fn1 = () => { fn2() }\n",
+      filename: "./src/foo.js",
+    },
+    {
+      code: "//@level 2\nconst {dat, fn2} = someFn()\nconst fn1 = () => { fn2() }\n",
+      filename: "./src/foo.js",
+    },
+    {
+      code: "//@level 2\nconst {dat, fn2: func2} = someFn()\nconst fn1 = () => { func2() }\n",
+      filename: "./src/foo.js",
+    },
   ],
   invalid: [
     {
@@ -376,6 +389,22 @@ ruleTester.run("no-same-level-funcs", rule, {
       code: "const func3 = () => {}; const arr = [{a: {b: {c: [func3]}}}]; const func1 = () => arr[0].a.b.c[0]();",
       filename: "./src/foo.js",
       errors: [{ messageId: "no-same-level-funcs", data: { func: "arr" } }],
+    },
+
+    {
+      code: "const [dat, fn2] = someFn()\nconst fn1 = () => { fn2() }\n",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "fn2" } }],
+    },
+    {
+      code: "const {dat, fn2} = someFn()\nconst fn1 = () => { fn2() }\n",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "fn2" } }],
+    },
+    {
+      code: "const {dat, fn2: func2} = someFn()\nconst fn1 = () => { func2() }\n",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "func2" } }],
     },
   ],
 });


### PR DESCRIPTION
### no-same-level-funcs

#### invalid
```ts
const [dat, fn2] = someFn()
const fn1 = () => fn2()
```
```ts
const {dat, fn2} = someFn()
const fn1 = () => fn2()
```

#### valid
```ts
// @level 2
const [dat, fn2] = someFn()
const fn1 = () => fn2()
```
```ts
// @level 2
const {dat, fn2} = someFn()
const fn1 = () => fn2()
```