### PR TITLE
[no-same-level-funcs] @data

### DIFF
--- a/docs/rules/no-same-level-funcs.md
+++ b/docs/rules/no-same-level-funcs.md
@@ -115,4 +115,10 @@ const funcC = (...) => {
   funcB(...)
   ...
 }
+
+// @data
+const data = (() => 'a')();
+// @level 2
+const funcC2 = (data) => data;
+const funcC1 = funcC2(data)
 ```

--- a/docs/rules/no-same-level-funcs.md
+++ b/docs/rules/no-same-level-funcs.md
@@ -85,6 +85,11 @@ const funcC = (...) => {
 }
 ```
 
+```js
+const func = () => "a";
+const obj = { a: func() };
+```
+
 Examples of **correct** code for this rule:
 
 ```js
@@ -115,10 +120,10 @@ const funcC = (...) => {
   funcB(...)
   ...
 }
+```
 
+```js
+const func = () => "a";
 // @data
-const data = (() => 'a')();
-// @level 2
-const funcC2 = (data) => data;
-const funcC1 = funcC2(data)
+const obj = { a: func() };
 ```

--- a/lib/helpers/common.js
+++ b/lib/helpers/common.js
@@ -134,6 +134,24 @@ const match = (path) => {
   return (pattern) => minimatch(path, pattern);
 };
 
+/**
+ * @template T
+ * @param  {...(() => T)} args
+ * @returns {T | undefined}
+ */
+const or = (...args) => {
+  for (const arg of args) {
+    try {
+      const result = arg();
+      if (result !== undefined) return result;
+      else continue;
+    } catch (e) {
+      continue;
+    }
+  }
+  return undefined;
+};
+
 module.exports = {
   toRelative,
   toSegments,
@@ -149,4 +167,5 @@ module.exports = {
   replaceAlias,
   fromCwd,
   match,
+  or,
 };

--- a/lib/rules/no-same-level-funcs.js
+++ b/lib/rules/no-same-level-funcs.js
@@ -1,17 +1,16 @@
 /**
  * @fileoverview Disallow calling functions in the same file.
  * @author Hodoug Joung
+ * @description 최상위에 있는 node가 함수인지 데이터인지 구분하지 않고 모두 함수로 취급힌다. (데이터인 경우에는 주석으로 '@data'를 붙여줘야 한다. 단, 명백하게 데이터인 경우에는 그 주석을 붙여주지 않아도 된다.)
  */
 "use strict";
 
 const path = require("path");
-const { fromCwd, match } = require("../helpers/common");
+const { fromCwd, match, or } = require("../helpers/common");
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
-
-// FIXME: const Body = styled.div``; const Body2 = styled(Body)`` (TaggedTemplateExpression)
 
 /**
  * @typedef {import('eslint').Rule.Node} Node
@@ -20,131 +19,91 @@ const { fromCwd, match } = require("../helpers/common");
  * @typedef {({[name: string]: number})} Levels
  */
 
-const hasArrFunction = (elements, levels) => {
-  return elements.reduce((hasFunc, element) => {
-    if (hasFunc) return true;
-    const type = element.type;
-    if (type === "FunctionExpression" || type === "ArrowFunctionExpression")
-      return true;
-    if (type === "ObjectExpression")
-      return hasObjFunction(element.properties, levels);
-    if (type === "ArrayExpression")
-      return hasArrFunction(element.elements, levels);
-    if ("name" in element && element.name in levels) return true;
-    return false;
-  }, false);
-};
-
-const hasObjFunction = (properties, levels) => {
-  return properties.reduce((hasFunc, property) => {
-    if (hasFunc) return true;
-    if (!("value" in property)) return false;
-    const type = property.value.type;
-    if (type === "FunctionExpression" || type === "ArrowFunctionExpression")
-      return true;
-    if (type === "ObjectExpression")
-      return hasObjFunction(property.value.properties, levels);
-    if (type === "ArrayExpression")
-      return hasArrFunction(property.value.elements, levels);
-    if ("name" in property.value && property.value.name in levels) return true;
-    return false;
-  }, false);
-};
-
 /**
  * @param {Node | Token} nodeOrToken
  */
 const deriveDeclaration = (nodeOrToken) => {
-  return (nodeOrToken.type === "ExportNamedDeclaration" ||
-    nodeOrToken.type === "ExportDefaultDeclaration") &&
+  const declaration =
+    (nodeOrToken.type === "ExportNamedDeclaration" ||
+      nodeOrToken.type === "ExportDefaultDeclaration") &&
     Boolean(nodeOrToken.declaration)
-    ? nodeOrToken.declaration
-    : nodeOrToken;
+      ? nodeOrToken.declaration
+      : nodeOrToken;
+  return or(
+    () => declaration.declarations[0],
+    () => declaration
+  );
 };
 
-/**
- * @param {Node | Token} nodeOrToken
- * @returns {string | null}
- */
-const deriveFuncName = (nodeOrToken) => {
-  const declaration = deriveDeclaration(nodeOrToken);
+const isDataOrImported = (declarationInit, levels) => {
+  const expression = or(
+    () => declarationInit.expression,
+    () => declarationInit
+  );
+  if (!expression) return false;
 
-  if (declaration.type === "FunctionDeclaration") return declaration.id.name;
-  if (declaration.type !== "VariableDeclaration") return null;
-
-  const { init, id } = declaration.declarations[0];
-  if (
-    [
-      "ArrowFunctionExpression",
-      "FunctionExpression",
-      "CallExpression",
-      "TaggedTemplateExpression",
-    ].includes(init.type)
-  ) {
-    return id.name;
+  const type = expression.type;
+  if (type === "Literal") return true;
+  if (type === "Identifier") {
+    const name = or(() => expression.name);
+    return name && !levels[name];
   }
-
-  return null;
+  if (type === "MemberExpression") {
+    const name = or(() => expression.object.name);
+    return name && !levels[name];
+  }
+  if (type === "CallExpression") {
+    const name = or(() => expression.callee.name);
+    return name && !levels[name];
+  }
+  if (type === "JSXElement") {
+    const name = or(() => expression.openingElement.name.name);
+    return name && !levels[name];
+  }
+  if (type === "SpreadElement")
+    return isDataOrImported(expression.argument, levels);
+  if (type === "ArrayExpression")
+    return expression.elements.every((init) => isDataOrImported(init, levels));
+  if (type === "ObjectExpression")
+    return expression.properties.every(({ value }) =>
+      isDataOrImported(value, levels)
+    );
+  return false;
 };
 
 /**
  * @param {Node | Token} nodeOrToken
  * @param {Levels} levels
- * @returns {string | null}
+ * @returns {string[] | undefined}
  */
-const deriveVarName = (nodeOrToken, levels) => {
+const deriveNames = (nodeOrToken, levels) => {
   const declaration = deriveDeclaration(nodeOrToken);
-  if (declaration.type !== "VariableDeclaration") return null;
-  const { init, id } = declaration.declarations[0];
-  if (
-    init.type === "ObjectExpression" &&
-    hasObjFunction(init.properties, levels)
-  ) {
-    return id.name;
-  } else if (
-    init.type === "ArrayExpression" &&
-    hasArrFunction(init.elements, levels)
-  ) {
-    return id.name;
-  } else {
-    return null;
-  }
-};
-
-const or = (...args) => {
-  for (const arg of args) {
-    try {
-      const result = arg();
-      if (result) return result;
-      else continue;
-    } catch (e) {
-      continue;
-    }
-  }
-  return undefined;
-};
-
-const deriveNames = (nodeOrToken) => {
-  const declaration = deriveDeclaration(nodeOrToken);
+  if (isDataOrImported(declaration.init, levels)) return [];
   const names = or(
     () => declaration.id.name,
-    () => declaration.declarations[0].id.name,
-    () => declaration.declarations[0].id.elements.map(({ name }) => name),
-    () =>
-      declaration.declarations[0].id.properties.map(({ value }) => value.name)
+    () => declaration.id.elements.map(({ name }) => name),
+    () => declaration.id.properties.map(({ value }) => value.name)
   );
   return names === undefined ? [] : Array.isArray(names) ? names : [names];
 };
 
 /**
+ * @param {Node | Token} nodeOrToken
+ * @returns {string | undefined}
+ */
+const deriveCallerName = (nodeOrToken) =>
+  or(() => deriveDeclaration(nodeOrToken).id.name);
+
+/**
  * @param {SourceCode} sourceCode
  * @param {Node | Token} nodeOrToken
- *
+ * @returns {number | null}
  */
 const deriveLevel = (sourceCode, nodeOrToken) => {
   const comments = sourceCode.getCommentsBefore(nodeOrToken);
-  for (const { value } of comments) {
-    const levelInStr = value.replace(/^[^]*@level\s+?([0-9]+)[^0-9]*$/, "$1");
+  for (const { value: comment } of comments) {
+    if (comment.includes("@data") || comment.includes("@import")) return null;
+    const levelInStr = comment.replace(/^[^]*@level\s+?([0-9]+)[^0-9]*$/, "$1");
     const levelInNum = Number(levelInStr);
     if (levelInStr && !Number.isNaN(levelInNum)) {
       return levelInNum;
@@ -154,6 +113,7 @@ const deriveLevel = (sourceCode, nodeOrToken) => {
 };
 
 /**
+ * root node(Program) 바로 아래에 있는 부모 노드를 리턴한다.
  * @param {SourceCode} sourceCode
  * @param {Node} node
  */
@@ -175,7 +135,7 @@ const isCalleeLowerLevel = (sourceCode, levels) => {
     if (calleeLevel === undefined) return true; // 호출되는 함수가 존재하지 않으면 true 리턴. 함수 내의 함수의 경우에는 항상 calleeLevel 이 undefined 이다.
 
     const caller = traceAncestor(sourceCode, node);
-    const callerName = deriveFuncName(caller) || deriveVarName(caller, levels);
+    const callerName = deriveCallerName(caller);
     const callerLevel = levels[callerName];
 
     if (callerLevel === undefined) return true;
@@ -268,10 +228,19 @@ module.exports = {
     return {
       Program(node) {
         node.body.forEach((token) => {
-          deriveNames(token).forEach((name) => {
-            if (name) levels[name] = deriveLevel(sourceCode, token);
+          deriveNames(token, levels).forEach((name) => {
+            const level = deriveLevel(sourceCode, token);
+            if (name && level) levels[name] = level;
           });
         });
+      },
+      VariableDeclarator(node) {
+        const init = or(() => node.init.name);
+        const id = or(() => node.id.name);
+        if (!init || !id) return;
+        if (levels[init] && !levels[id]) {
+          levels[id] = levels[init];
+        }
       },
       CallExpression(node) {
         for (const { name } of node.arguments) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-stratified-design",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "description": "ESlint rules for stratified design",
   "keywords": [
     "eslint",
@@ -21,6 +21,7 @@
     "lint": "eslint .",
     "test": "mocha tests --recursive",
     "test:watch": "mocha tests --recursive --watch",
+    "test:single": "mocha tests --watch",
     "versioning": "node ./scripts/versioning"
   },
   "dependencies": {


### PR DESCRIPTION
### no-sname-level-funcs

Since we have decided to treat data as functions as well, the `@level` annotation must be used to assign a hierarchy. However, if the `@data` annotation is used, it is regarded as data, and no hierarchy is enforced.
