### PR TITLE
[no-same-level-funcs] fix `import` case

### DIFF
--- a/docs/rules/no-same-level-funcs.md
+++ b/docs/rules/no-same-level-funcs.md
@@ -127,3 +127,10 @@ const func = () => "a";
 // @data
 const obj = { a: func() };
 ```
+
+```js
+import { lib } from "module";
+//@import
+const { fn2 } = lib;
+const fn1 = () => fn2();
+```

--- a/lib/rules/no-same-level-funcs.js
+++ b/lib/rules/no-same-level-funcs.js
@@ -17,6 +17,7 @@ const { fromCwd, match, or } = require("../helpers/common");
  * @typedef {import('eslint').AST.Token} Token
  * @typedef {import('eslint').SourceCode} SourceCode
  * @typedef {({[name: string]: number})} Levels
+ * @typedef {({[name: string]: boolean})} DataNames
  */
 
 /**
@@ -35,7 +36,12 @@ const deriveDeclaration = (nodeOrToken) => {
   );
 };
 
-const isDataOrImported = (declarationInit, levels) => {
+/**
+ * @param {any} declarationInit
+ * @param {DataNames} dataNames
+ * @returns {boolean}
+ */
+const isData = (declarationInit, dataNames) => {
   const expression = or(
     () => declarationInit.expression,
     () => declarationInit
@@ -46,29 +52,36 @@ const isDataOrImported = (declarationInit, levels) => {
   if (type === "Literal") return true;
   if (type === "Identifier") {
     const name = or(() => expression.name);
-    return name && !levels[name];
+    return name && dataNames[name];
   }
   if (type === "MemberExpression") {
     const name = or(() => expression.object.name);
-    return name && !levels[name];
+    return name && dataNames[name];
   }
   if (type === "CallExpression") {
     const name = or(() => expression.callee.name);
-    return name && !levels[name];
+    return name && dataNames[name];
   }
   if (type === "JSXElement") {
     const name = or(() => expression.openingElement.name.name);
-    return name && !levels[name];
+    return name && dataNames[name];
   }
-  if (type === "SpreadElement")
-    return isDataOrImported(expression.argument, levels);
+  if (type === "SpreadElement") return isData(expression.argument, dataNames);
   if (type === "ArrayExpression")
-    return expression.elements.every((init) => isDataOrImported(init, levels));
+    return expression.elements.every((init) => isData(init, dataNames));
   if (type === "ObjectExpression")
-    return expression.properties.every(({ value }) =>
-      isDataOrImported(value, levels)
-    );
+    return expression.properties.every(({ value }) => isData(value, dataNames));
   return false;
+};
+
+/**
+ * @param {Node | Token} nodeOrToken
+ * @param {DataNames} dataNames
+ * @returns {boolean}
+ */
+const isNodeData = (nodeOrToken, dataNames) => {
+  const declaration = deriveDeclaration(nodeOrToken);
+  return isData(declaration.init, dataNames);
 };
 
 /**
@@ -76,9 +89,8 @@ const isDataOrImported = (declarationInit, levels) => {
  * @param {Levels} levels
  * @returns {string[] | undefined}
  */
-const deriveNames = (nodeOrToken, levels) => {
+const deriveNames = (nodeOrToken) => {
   const declaration = deriveDeclaration(nodeOrToken);
-  if (isDataOrImported(declaration.init, levels)) return [];
   const names = or(
     () => declaration.id.name,
     () => declaration.id.elements.map(({ name }) => name),
@@ -97,12 +109,37 @@ const deriveCallerName = (nodeOrToken) =>
 /**
  * @param {SourceCode} sourceCode
  * @param {Node | Token} nodeOrToken
- * @returns {number | null}
+ * @returns {boolean}
+ */
+const hasDataComment = (sourceCode, nodeOrToken) => {
+  const comments = sourceCode.getCommentsBefore(nodeOrToken);
+  for (const { value: comment } of comments) {
+    if (comment.includes("@data")) return true;
+  }
+  return false;
+};
+
+/**
+ * @param {SourceCode} sourceCode
+ * @param {Node | Token} nodeOrToken
+ * @returns {boolean}
+ */
+const hasImportComment = (sourceCode, nodeOrToken) => {
+  const comments = sourceCode.getCommentsBefore(nodeOrToken);
+  for (const { value: comment } of comments) {
+    if (comment.includes("@import")) return true;
+  }
+  return false;
+};
+
+/**
+ * @param {SourceCode} sourceCode
+ * @param {Node | Token} nodeOrToken
+ * @returns {number}
  */
 const deriveLevel = (sourceCode, nodeOrToken) => {
   const comments = sourceCode.getCommentsBefore(nodeOrToken);
   for (const { value: comment } of comments) {
-    if (comment.includes("@data") || comment.includes("@import")) return null;
     const levelInStr = comment.replace(/^[^]*@level\s+?([0-9]+)[^0-9]*$/, "$1");
     const levelInNum = Number(levelInStr);
     if (levelInStr && !Number.isNaN(levelInNum)) {
@@ -208,6 +245,12 @@ module.exports = {
      */
     const levels = {};
 
+    /**
+     * 선언된 것이 데이터인지 여부를 나타내는 객체.
+     * @type {DataNames}
+     */
+    const dataNames = {};
+
     const sourceCode = context.sourceCode;
 
     /**
@@ -228,9 +271,17 @@ module.exports = {
     return {
       Program(node) {
         node.body.forEach((token) => {
-          deriveNames(token, levels).forEach((name) => {
+          deriveNames(token).forEach((name) => {
+            if (!name || hasImportComment(sourceCode, token)) return;
+            if (
+              hasDataComment(sourceCode, token) ||
+              isNodeData(token, dataNames)
+            ) {
+              dataNames[name] = true;
+              return;
+            }
             const level = deriveLevel(sourceCode, token);
-            if (name && level) levels[name] = level;
+            levels[name] = level;
           });
         });
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-stratified-design",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "description": "ESlint rules for stratified design",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/no-same-level-funcs.js
+++ b/tests/lib/rules/no-same-level-funcs.js
@@ -268,35 +268,7 @@ ruleTester.run("no-same-level-funcs", rule, {
       filename: "./src/foo.js",
     },
     {
-      code: "import { lib } from 'lib'; const { fn2 } = lib; const fn1 = () => fn2()",
-      filename: "./src/foo.js",
-    },
-    {
-      code: "import { lib } from 'lib'; const fn2 = lib.fn2; const fn1 = () => fn2()",
-      filename: "./src/foo.js",
-    },
-    {
-      code: "import { fn2 } from 'lib'; const arr = [fn2]; const fn1 = () => arr[0]()",
-      filename: "./src/foo.js",
-    },
-    {
-      code: "import { fn2 } from 'lib'; const arr = [fn2()]; const fn1 = () => arr.push(1)",
-      filename: "./src/foo.js",
-    },
-    {
-      code: "import { fn2 } from 'lib'; const data = [...fn2()]; const fn1 = () => data.push(1)",
-      filename: "./src/foo.js",
-    },
-    {
-      code: "import { fn2 } from 'lib'; const arr = [fn2]; const fn1 = () => arr.push(1)",
-      filename: "./src/foo.js",
-    },
-    {
-      code: "import { Comp2 } from 'lib'; const arr = [<Comp2 />]; const fn1 = () => arr.push(1)",
-      filename: "./src/foo.js",
-    },
-    {
-      code: "import { Comp2 } from 'lib'; const arr = [Comp2]; const fn1 = () => arr.push(1)",
+      code: "import { lib } from 'lib'; /*@import*/const { fn2 } = lib; const fn1 = () => fn2()",
       filename: "./src/foo.js",
     },
   ],
@@ -482,6 +454,52 @@ ruleTester.run("no-same-level-funcs", rule, {
       code: "const fn2 = () => {}; const fn1 = () => { const _fn2 = fn2; const __fn2 = _fn2; __fn2()}",
       filename: "./src/foo.js",
       errors: [{ messageId: "no-same-level-funcs", data: { func: "__fn2" } }],
+    },
+
+    {
+      code: "import { lib } from 'lib'; const { fn2 } = lib; const fn1 = () => fn2()",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "fn2" } }],
+    },
+    {
+      code: "import { lib } from 'lib'; const fn2 = lib.fn2; const fn1 = () => fn2()",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "fn2" } }],
+    },
+    {
+      code: "import { fn2 } from 'lib'; const arr = [fn2]; const fn1 = () => arr[0]()",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "arr" } }],
+    },
+    {
+      code: "import { hof1, hof2 } from 'lib'; const fn2 = hof2(); const fn1 = () => hof1(fn2)",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "fn2" } }],
+    },
+    {
+      code: "import { fn2 } from 'lib'; const arr = [fn2()]; const fn1 = () => arr.push(1)",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "arr" } }],
+    },
+    {
+      code: "import { fn2 } from 'lib'; const data = [...fn2()]; const fn1 = () => data.push(1)",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "data" } }],
+    },
+    {
+      code: "import { fn2 } from 'lib'; const arr = [fn2]; const fn1 = () => arr.push(1)",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "arr" } }],
+    },
+    {
+      code: "import { Comp2 } from 'lib'; const arr = [<Comp2 />]; const fn1 = () => arr.push(1)",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "arr" } }],
+    },
+    {
+      code: "import { Comp2 } from 'lib'; const arr = [Comp2]; const fn1 = () => arr.push(1)",
+      filename: "./src/foo.js",
+      errors: [{ messageId: "no-same-level-funcs", data: { func: "arr" } }],
     },
   ],
 });


### PR DESCRIPTION
### no-same-level-funcs

- fix bugs related to `import`
- `@import`: 
  - example
      ```js
      import { lib } from "module";
      //@import
      const { fn2 } = lib;
      const fn1 = () => fn2();
      ```